### PR TITLE
SignedToken supports `isUrlSafe` when BASE64 works

### DIFF
--- a/src/main/java/com/google/gwtjsonrpc/server/SignedToken.java
+++ b/src/main/java/com/google/gwtjsonrpc/server/SignedToken.java
@@ -14,14 +14,15 @@
 
 package com.google.gwtjsonrpc.server;
 
+import org.apache.commons.codec.binary.Base64;
+
+import javax.crypto.Mac;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.SecretKeySpec;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Arrays;
-import javax.crypto.Mac;
-import javax.crypto.ShortBufferException;
-import javax.crypto.spec.SecretKeySpec;
-import org.apache.commons.codec.binary.Base64;
 
 /**
  * Utility function to compute and verify XSRF tokens.
@@ -45,7 +46,7 @@ public class SignedToken {
   public static String generateRandomKey() {
     final byte[] r = new byte[26];
     new SecureRandom().nextBytes(r);
-    return encodeBase64(r);
+    return encodeBase64(r, false);
   }
 
   private final int maxAge;
@@ -72,7 +73,7 @@ public class SignedToken {
    */
   public SignedToken(final int age, final String keyBase64) throws XsrfException {
     maxAge = age > 5 ? age / 5 : age;
-    key = new SecretKeySpec(decodeBase64(keyBase64), MAC_ALG);
+    key = new SecretKeySpec(decodeBase64(keyBase64, false), MAC_ALG);
     rng = new SecureRandom();
     tokenLength = 2 * INT_SZ + newMac().getMacLength();
   }
@@ -109,13 +110,34 @@ public class SignedToken {
    *     in the returned token string.
    * @throws XsrfException the JVM doesn't support the necessary algorithms.
    */
+  @Deprecated
   public String newToken(final String text) throws XsrfException {
     final int q = rng.nextInt();
     final byte[] buf = new byte[tokenLength];
     encodeInt(buf, 0, q);
     encodeInt(buf, INT_SZ, now() ^ q);
     computeToken(buf, text);
-    return encodeBase64(buf) + '$' + text;
+    return encodeBase64(buf, false) + '$' + text;
+  }
+
+  /**
+   * Generate a new signed token.
+   *
+   * @param text      the text string to sign. Typically this should be some user-specific string, to prevent replay
+   *                  attacks. The text must be safe to appear in whatever context the token itself will appear, as
+   *                  the text is included on the end of the token.
+   * @param isUrlSafe the flag of url safe mode when BASE64 is encoding and decoding
+   * @return the signed token. The text passed in <code>text</code> will appear after the first ',' in the returned
+   * token string.
+   * @throws XsrfException the JVM doesn't support the necessary algorithms.
+   */
+  public String newToken(final String text, final boolean isUrlSafe) throws XsrfException {
+    final int q = rng.nextInt();
+    final byte[] buf = new byte[tokenLength];
+    encodeInt(buf, 0, q);
+    encodeInt(buf, INT_SZ, now() ^ q);
+    computeToken(buf, text);
+    return encodeBase64(buf, isUrlSafe) + '$' + text;
   }
 
   /**
@@ -129,6 +151,7 @@ public class SignedToken {
    * @throws XsrfException the JVM doesn't support the necessary algorithms to generate a token.
    *     XSRF services are simply not available.
    */
+  @Deprecated
   public ValidToken checkToken(final String tokenString, final String text) throws XsrfException {
     if (tokenString == null || tokenString.length() == 0) {
       return null;
@@ -142,7 +165,57 @@ public class SignedToken {
     final String recvText = tokenString.substring(s + 1);
     final byte[] in;
     try {
-      in = decodeBase64(tokenString.substring(0, s));
+      in = decodeBase64(tokenString.substring(0, s), false);
+    } catch (RuntimeException e) {
+      return null;
+    }
+    if (in.length != tokenLength) {
+      return null;
+    }
+
+    final int q = decodeInt(in, 0);
+    final int c = decodeInt(in, INT_SZ) ^ q;
+    final int n = now();
+    if (maxAge > 0 && Math.abs(c - n) > maxAge) {
+      return null;
+    }
+
+    final byte[] gen = new byte[tokenLength];
+    System.arraycopy(in, 0, gen, 0, 2 * INT_SZ);
+    computeToken(gen, text != null ? text : recvText);
+    if (!Arrays.equals(gen, in)) {
+      return null;
+    }
+
+    return new ValidToken(maxAge > 0 && c + (maxAge >> 1) <= n, recvText);
+  }
+
+  /**
+   * Validate a returned token.
+   *
+   * @param tokenString a token string previously created by this class.
+   * @param text        text that must have been used during {@link #newToken(String)} in order for the token to be
+   *                    valid. If null the text will be taken from the token string itself. * @param
+   * @param isUrlSafe   the flag of url safe mode when BASE64 is encoding and decoding
+   * @return true if the token is valid; false if the token is null, the empty string, has expired, does not match the
+   * text supplied, or is a forged token.
+   * @throws XsrfException the JVM doesn't support the necessary algorithms to generate a token. XSRF services are
+   *                       simply not available.
+   */
+  public ValidToken checkToken(final String tokenString, final String text, final boolean isUrlSafe) throws XsrfException {
+    if (tokenString == null || tokenString.length() == 0) {
+      return null;
+    }
+
+    final int s = tokenString.indexOf('$');
+    if (s <= 0) {
+      return null;
+    }
+
+    final String recvText = tokenString.substring(s + 1);
+    final byte[] in;
+    try {
+      in = decodeBase64(tokenString.substring(0, s), isUrlSafe);
     } catch (RuntimeException e) {
       return null;
     }
@@ -191,20 +264,21 @@ public class SignedToken {
   }
 
   private static int now() {
-    return (int) (System.currentTimeMillis() / 5000L);
+    return (int)(System.currentTimeMillis() / 5000L);
   }
 
-  private static byte[] decodeBase64(final String s) {
-    return Base64.decodeBase64(toBytes(s));
+  private static byte[] decodeBase64(final String s, final boolean isUrlSafe) {
+    return new Base64(isUrlSafe).decode(toBytes(s));
+
   }
 
-  private static String encodeBase64(final byte[] buf) {
-    return toString(Base64.encodeBase64(buf));
+  private static String encodeBase64(final byte[] buf, final boolean isUrlsafe) {
+    return toString(new Base64(isUrlsafe).encode(buf));
   }
 
   private static void encodeInt(final byte[] buf, final int o, final int v) {
     int _v = v;
-    buf[o + 3] = (byte) _v;
+    buf[o + 3] = (byte)_v;
     _v >>>= 8;
 
     buf[o + 2] = (byte) _v;


### PR DESCRIPTION
There is a problem that if the token is used as a HTTP Request Parameter
in URL, the verification of `SignedToken` will be always a failure.

	BASE64 scope : A-Z a-z 0-9 + / =
	URL transfer scope: + SPACE / ? % # & =

For an example, When the token contains char '+', the parameter of token
will treat this char as a SPACE characther.  So, it's strongly needed
for `new` and `check` to support whether to use `isUrlSafe` flag to avoid
the runtime verification problems.

PS: Problem was found in Gerrit email confirm API, if token contains '+'
the verfiy will be failed.